### PR TITLE
Complain about all properties registered using requiredProperties

### DIFF
--- a/src/main/groovy/net/saliman/gradle/plugin/properties/PropertiesPlugin.groovy
+++ b/src/main/groovy/net/saliman/gradle/plugin/properties/PropertiesPlugin.groovy
@@ -448,9 +448,9 @@ class PropertiesPlugin implements Plugin<PluginAware> {
 
             // now add the one that takes a list...
             task.ext.requiredProperties = { String[] propertyNames ->
-                project.gradle.taskGraph.whenReady { graph ->
-                    if ( graph.hasTask(task.path) ) {
-                        for ( propertyName in propertyNames ) {
+                for ( propertyName in propertyNames ) {
+                    project.gradle.taskGraph.whenReady { graph ->
+                        if ( graph.hasTask(task.path) ) {
                             checkProperty(project, propertyName, task, "requiredProperties")
                         }
                     }


### PR DESCRIPTION
Before this PR only the first property of a given `requiredProperties` call was complained about even if multiple were missing, with this, you get a complaint for each that is missing.